### PR TITLE
move conversion to BSON::Document from Matcher#extract_attribute to Expression#matches?

### DIFF
--- a/lib/mongoid/matcher.rb
+++ b/lib/mongoid/matcher.rb
@@ -36,13 +36,6 @@ module Mongoid
     #   Whether the value existed in the document, the extracted value
     #   and the array expansion flag.
     module_function def extract_attribute(document, key)
-      if document.respond_to?(:as_attributes, true)
-        # If a document has hash fields, as_attributes would keep those fields
-        # as Hash instances which do not offer indifferent access.
-        # Convert to BSON::Document to get indifferent access on hash fields.
-        document = BSON::Document.new(document.send(:as_attributes))
-      end
-
       current = [document]
 
       key.to_s.split('.').each do |field|

--- a/lib/mongoid/matcher/expression.rb
+++ b/lib/mongoid/matcher/expression.rb
@@ -10,6 +10,12 @@ module Mongoid
         unless Hash === expr
           raise Errors::InvalidQuery, "MQL query must be provided as a Hash"
         end
+        if !(document === BSON::Document) && document.respond_to?(:as_attributes, true)
+          # If a document has hash fields, as_attributes would keep those fields
+          # as Hash instances which do not offer indifferent access.
+          # Convert to BSON::Document to get indifferent access on hash fields.
+          document = BSON::Document.new(document.send(:as_attributes))
+        end
         expr.all? do |k, expr_v|
           k = k.to_s
           if k.start_with?('$')


### PR DESCRIPTION
`extract_attribute` is called pretty frequently during the `matches?` codepath, especially for a large selector, so instead of converting to a `BSON::Document` on each call to `extract_attribute`, convert at the beginning of `matches?`