### PR TITLE
[APPI-1223] > Matcher.extract_attribute perf

### DIFF
--- a/spec/integration/matcher_spec.rb
+++ b/spec/integration/matcher_spec.rb
@@ -114,6 +114,39 @@ describe 'Matcher operators' do
       end
     end
 
+    context "array hash field" do
+      let(:document) do
+        Cart.new(
+          items: [
+            {
+              name: 'foo'
+            },
+            {
+              name: 'bar'
+            },
+          ],
+        )
+      end
+
+      context 'implicit $eq' do
+        context 'matches' do
+          let(:query) do
+            {'items.name' => 'foo'}
+          end
+
+          it_behaves_like 'is true'
+        end
+
+        context 'does not match' do
+          let(:query) do
+            {'items.name' => 'missing'}
+          end
+
+          it_behaves_like 'is false'
+        end
+      end
+    end
+
     context 'embeds_many' do
       let(:document) do
         Survey.new(

--- a/spec/integration/matcher_spec.rb
+++ b/spec/integration/matcher_spec.rb
@@ -116,8 +116,8 @@ describe 'Matcher operators' do
 
     context "array hash field" do
       let(:document) do
-        Cart.new(
-          items: [
+        Band.new(
+          genres: [
             {
               name: 'foo'
             },
@@ -131,7 +131,7 @@ describe 'Matcher operators' do
       context 'implicit $eq' do
         context 'matches' do
           let(:query) do
-            {'items.name' => 'foo'}
+            {'genres.name' => 'foo'}
           end
 
           it_behaves_like 'is true'
@@ -139,7 +139,7 @@ describe 'Matcher operators' do
 
         context 'does not match' do
           let(:query) do
-            {'items.name' => 'missing'}
+            {'genres.name' => 'missing'}
           end
 
           it_behaves_like 'is false'

--- a/spec/support/models/cart.rb
+++ b/spec/support/models/cart.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-# encoding: utf-8
-
-class Cart 
-  include Mongoid::Document
-
-  field :items, type: Array
-end

--- a/spec/support/models/cart.rb
+++ b/spec/support/models/cart.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# encoding: utf-8
+
+class Cart 
+  include Mongoid::Document
+
+  field :items, type: Array
+end


### PR DESCRIPTION
- Improves Matcher.extract_attribute performance by eliminating Document
  initialization.
- Upstream, this improves the performance of _matches?.