### PR TITLE
Update Time comparisons with `_matches?` to follow upstream Mongoid

### DIFF
--- a/lib/mongoid/extensions/time_with_zone.rb
+++ b/lib/mongoid/extensions/time_with_zone.rb
@@ -30,6 +30,19 @@ module Mongoid
         ::ActiveSupport::TimeWithZone.mongoize(self)
       end
 
+      # This code is copied from Time class extension in bson-ruby gem. It
+      # should be removed from here when added to bson-ruby.
+      # See https://jira.mongodb.org/browse/RUBY-2846.
+      def _bson_to_i
+        # Workaround for JRuby's #to_i rounding negative timestamps up
+        # rather than down (https://github.com/jruby/jruby/issues/6104)
+        if BSON::Environment.jruby?
+          (self - usec.to_r/1000000).to_i
+        else
+          to_i
+        end
+      end
+
       module ClassMethods
 
         # Convert the object from its mongo friendly ruby type to this type.

--- a/lib/mongoid/matcher/eq_impl.rb
+++ b/lib/mongoid/matcher/eq_impl.rb
@@ -55,7 +55,7 @@ module Mongoid
       end
 
       module_function def time_rounded_to_millis(time)
-        return time.utc._bson_to_i * 1000 + time.usec.divmod(1000).first
+        return time._bson_to_i * 1000 + time.usec.divmod(1000).first
       end
     end
   end


### PR DESCRIPTION
Update to the change from https://github.com/braze-inc/mongoid/pull/6

This cherry-picks a change from https://github.com/mongodb/mongoid/pull/5094 that removes the need for calling `.utc` on a `ActiveSupport::TimeWithZone` value by defining `ActiveSupport::TimeWithZon#_bson_to_i`