### PR TITLE
WIP: Don't allow ruby to coerce field types when evaluating segmenting criteria

### DIFF
--- a/lib/mongoid/matcher/field_operator.rb
+++ b/lib/mongoid/matcher/field_operator.rb
@@ -35,7 +35,15 @@ module Mongoid
       end
 
       module_function def apply_comparison_operator(operator, left, right)
-        left.send(operator, right)
+        if left.is_a?(Numeric) && right.is_a?(Numeric)
+          left.send(operator, right)
+        elsif (left.is_a?(Date) || left.is_a?(Time)) && (right.is_a?(Date) || right.is_a?(Time))
+          left.send(operator, right)
+        elsif left.is_a?(String) && right.is_a?(String)
+          left.send(operator, right)
+        else
+          false
+        end
       rescue ArgumentError, NoMethodError, TypeError
         # We silence bogus comparison attempts, e.g. number to string
         # comparisons.


### PR DESCRIPTION
We are seeing different behavior between the evaluation of segments and filters in memory/ruby/mongoid versus when truly querying mongo.  Ruby is coercing _string_ values such as "2022-04-06" into Date values and comparing them with real dates, whereas Mongo does not do this, thus we get different results from the User Lookup tool and the Calculate Exact Statistics button.

Additionally, per Zach, trigger campaigns use the in-memory evaluator while scheduled campaigns use the in-mongo evaluator so this could mean different eligibility for users depending on the type of campaign which is probably even more troublesome than the bug request that brought us here.

More detail from slack behavior confirmation request available [here](https://brazetechnology.slack.com/archives/C0181S1SSSY/p1670274506972649)

Bug ticket: https://jira.braze.com/browse/UT-405

CM started to take a look at this as a result of a bug confirmation request but we think this falls more appropriately under UT team.  Solution is not a final suggestion and also clearly needs tests

Co-authored by @zachmccormick
Co-authored by @binderjared 