### PR TITLE
Forward explain options to driver

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -38,6 +38,16 @@ module Mongoid
       # @attribute [r] view The Mongo collection view.
       attr_reader :view
 
+      # Run an explain on the criteria.
+      #
+      # @example Explain the criteria.
+      #   Band.where(name: "Depeche Mode").explain
+      #
+      # @param [ Hash ] options customizable options (See Mongo::Collection::View::Explainable)
+      #
+      # @return [ Hash ] The explain result.
+      def_delegator :view, :explain
+
       # Is the context cached?
       #
       # @example Is the context cached?
@@ -181,18 +191,6 @@ module Mongoid
         try_cache(:exists) do
           !!(view.projection(_id: 1).limit(1).first)
         end
-      end
-
-      # Run an explain on the criteria.
-      #
-      # @example Explain the criteria.
-      #   Band.where(name: "Depeche Mode").explain
-      #
-      # @return [ Hash ] The explain result.
-      #
-      # @since 3.0.0
-      def explain
-        view.explain
       end
 
       # Execute the find and modify command, used for MongoDB's

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -806,7 +806,16 @@ describe Mongoid::Contextual::Mongo do
     end
 
     it "returns the criteria explain path" do
-      expect(context.explain).to_not be_empty
+      explain = context.explain
+      expect(explain).to_not be_empty
+      expect(explain.keys).to include("queryPlanner", "executionStats", "serverInfo")
+    end
+
+    it "respects options passed to explain" do
+      explain = context.explain(verbosity: :query_planner)
+      expect(explain).to_not be_empty
+      expect(explain.keys).to include("queryPlanner", "serverInfo")
+      expect(explain.keys).not_to include("executionStats")
     end
   end
 


### PR DESCRIPTION
Port of https://github.com/mongodb/mongoid/pull/5594 to our fork

This allows callers to adjust any available `explain` options, as documented here:

https://www.mongodb.com/docs/ruby-driver/master/api/Mongo/Collection/View/Explainable.html

One use case for this is running explain to get a query plan without actually executing the query, which is potentially slow, via

`explain(verbosity: :query_planner)`